### PR TITLE
Tool: view pdf attachments directly (raw view)

### DIFF
--- a/markdown/backend/minipython-builder.md
+++ b/markdown/backend/minipython-builder.md
@@ -13,7 +13,7 @@ outcomes:
 assignments:
     -   topic: sheet04
 attachments:
-    -   link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/minipython-builder.ann.ba.pdf"
+    -   link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/minipython-builder.ann.ba.pdf"
         name: "Annotierte Folien: Minipython CBuilder"
 ---
 

--- a/markdown/frontend/lexing/regular.md
+++ b/markdown/frontend/lexing/regular.md
@@ -18,7 +18,7 @@ outcomes:
   - k3: "DFAs, reguläre Ausdrücke, reguläre Grammatiken entwickeln"
   - k3: "Einen DFA entwickeln, der alle Schlüsselwörter, Namen und weitere Symbole einer Programmiersprache akzeptiert"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/lexing_regular.ann.ba.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/lexing_regular.ann.ba.pdf"
     name: "Annotierte Folien: Reguläre Sprachen, Ausdrucksstärke"
 ---
 

--- a/markdown/frontend/parsing/cfg.md
+++ b/markdown/frontend/parsing/cfg.md
@@ -13,7 +13,7 @@ outcomes:
   - k1: "Deterministisch kontextfreie Grammatiken"
   - k2: "Zusammenhang zwischen PDAs und kontextfreien Grammatiken"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/frontend_parsing_cfg.ann.ba.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/frontend_parsing_cfg.ann.ba.pdf"
     name: "Annotierte Folien: CFG, LL-Parser"
 ---
 

--- a/markdown/frontend/parsing/ll-parser-theory.md
+++ b/markdown/frontend/parsing/ll-parser-theory.md
@@ -14,7 +14,7 @@ outcomes:
   - k2: "Schreiben von LL-Parsern"
   - k3: "Top-Down Analyse programmieren"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/ll-parser-theory.ann.ba.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/ll-parser-theory.ann.ba.pdf"
     name: "Annotierte Folien: LL-Parser (Theorie)"
 ---
 

--- a/markdown/frontend/semantics/attribgrammars.md
+++ b/markdown/frontend/semantics/attribgrammars.md
@@ -14,7 +14,7 @@ outcomes:
   - k2: "Umsetzung von SDD mit Hilfe von SDT"
   - k3: "Einfache semantische Analyse mit Hilfe von attributierten Grammatiken"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/semantics_attribgrammars.ann.ba.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/semantics_attribgrammars.ann.ba.pdf"
     name: "Annotierte Folien: Typen und attributierte Grammatiken"
 ---
 


### PR DESCRIPTION
Nutze die URL `raw.githubusercontent.com`, um die PDF-Attachments zu verlinken. Dadurch werden sie direkt angezeigt (in der "normalen" Ansicht sieht man nur die ersten 2..3 Seiten und muss dann mühsam vorwärtsklicken und die nächsten Seiten "freischalten").