### PR TITLE
Lecture: replace braces in math

### DIFF
--- a/lecture/frontend/lexing/regular.md
+++ b/lecture/frontend/lexing/regular.md
@@ -44,7 +44,7 @@ $\epsilon$ ist das leere Wort.
 Die _Länge_ $\vert w \vert$ eines Wortes $w$ ist die Anzahl von Buchstaben, die es enthält (Kardinalität).
 
 **Def.:**
-$\Sigma^k = \{w\ \text{über}\ \Sigma\ \vert\ \vert w \vert = k \}$
+$\Sigma^k = \lbrace w\ \text{über}\ \Sigma\ \vert\ \vert w \vert = k \rbrace$
 
 $\Sigma^{\ast} = \bigcup\limits_{i \in \mathbb{N}_0} \Sigma^i$ (die Kleene-Hülle von $\Sigma$)
 
@@ -81,7 +81,7 @@ $A = (Q, \Sigma, \delta, q_0, F)$ mit
 
  **Def.:** Die Sprache eines DFA $A\ L(A)$ ist definiert durch:
 
-$L(A) =\{w\ \vert \delta^{\ast}(q_0, w) \in F \}$
+$L(A) =\lbrace w\ \vert \delta^{\ast}(q_0, w) \in F \rbrace$
 
 ## Beispiel
 
@@ -98,12 +98,12 @@ $L(A) =\{w\ \vert \delta^{\ast}(q_0, w) \in F \}$
 
  **Def.:** Seien *L* und *M* Sprachen.
 
-*    $L \cup M = \{w \mid w \in L \vee w \in M \}$
-*    $LM = L \cdot M = L \circ M = \{vw \mid v \in L \land w \in M\}$
+*    $L \cup M = \lbrace w \mid w \in L \vee w \in M \rbrace$
+*    $LM = L \cdot M = L \circ M = \lbrace vw \mid v \in L \land w \in M\rbrace$
 *    Die Kleene-Hülle einer Sprache:
-        *    Basis: $L^0 = \{\epsilon\}$
-        *    Induktion: $L^i = \{xw\mid x \in L^{i-1}, w \in L, i >
-             0\}$, \newline $L^{\ast} = \bigcup\limits_{i \ge 0}L^i$, \newline $L^+ = \bigcup\limits_{i > 0}L^i$
+        *    Basis: $L^0 = \lbrace \epsilon\rbrace$
+        *    Induktion: $L^i = \lbrace xw\mid x \in L^{i-1}, w \in L, i >
+             0\rbrace$, \newline $L^{\ast} = \bigcup\limits_{i \ge 0}L^i$, \newline $L^+ = \bigcup\limits_{i > 0}L^i$
 
 
 ## Reguläre Ausdrücke
@@ -112,8 +112,8 @@ $L(A) =\{w\ \vert \delta^{\ast}(q_0, w) \in F \}$
 
 *    Basis:
      *    $\epsilon$ und $\emptyset$ sind reguläre Ausdrücke mit $L(\epsilon) =
-            \{\epsilon\}$, $L(\emptyset)=\emptyset$
-     *    Sei $a$ ein Symbol $\Rightarrow$ $a$ ist ein regex mit $L(a) = \{a\}$
+            \lbrace \epsilon\rbrace$, $L(\emptyset)=\emptyset$
+     *    Sei $a$ ein Symbol $\Rightarrow$ $a$ ist ein regex mit $L(a) = \lbrace a\rbrace$
 *    Induktion: Seien $E,\ F$ reguläre Ausdrücke. Dann gilt:
      *    $E+F$ ist ein regex und bezeichnet die Vereinigung $L(E + F) = L(E)\cup L(F)$
      *    $EF$ ist ein regex und bezeichnet die Konkatenation $L(EF) = L(E)L(F)$
@@ -157,7 +157,7 @@ $\alpha A \beta \Rightarrow \alpha \gamma \beta$ ($\alpha A \beta$ leitet $\alph
         $\beta\Rightarrow \gamma$ dann $\alpha \overset{\ast}{\Rightarrow} \gamma$
 
 **Def.:** {Sei $G = (N, T ,P, S)$ eine formale Grammatik.
-    Dann ist $L(G) = \{w \in T^{\ast} \mid S \overset{\ast}{\Rightarrow} w\}$ die von $G$ erzeugte Sprache.
+    Dann ist $L(G) = \lbrace w \in T^{\ast} \mid S \overset{\ast}{\Rightarrow} w\rbrace$ die von $G$ erzeugte Sprache.
 
 
 ## Reguläre Grammatiken

--- a/lecture/frontend/parsing/cfg.md
+++ b/lecture/frontend/parsing/cfg.md
@@ -80,7 +80,7 @@ Bei jedem Zustandsübergang wird ein Zeichen (oder $\epsilon$) aus der Eingabe g
 ## Beispiel
 
 
-![Ein PDA für $L=\{ww^{R}\mid w\in \{a,b\}^{\ast}\}$](images/pda2.png){width="45%"}
+![Ein PDA für $L=\lbrace ww^{R}\mid w\in \lbrace a,b\rbrace^{\ast}\rbrace$](images/pda2.png){width="45%"}
 
 
 ## Konfigurationen von PDAs
@@ -116,12 +116,12 @@ induktiv wie folgt:
 ## Akzeptierte Sprachen
 
 **Def.:** Sei $P=(Q, \Sigma, \Gamma, \delta, q_0, \perp, F)$ ein PDA. Dann ist die *über einen Endzustand*
-akzeptierte Sprache $L(P) = \{w \mid (q_0, w, \perp) \overset{\ast}{\vdash} (q, \epsilon, \alpha)\}$
+akzeptierte Sprache $L(P) = \lbrace w \mid (q_0, w, \perp) \overset{\ast}{\vdash} (q, \epsilon, \alpha)\rbrace$
 für einen Zustand $q \in F, \alpha \in \Gamma^{\ast}$.
 
 **Def.:** Für einen PDA $P=(Q, \Sigma, \Gamma, \delta, q_{0}, \perp, F)$
 definieren wir die über den *leeren Keller* akzeptierte Sprache
-$N(P) = \{(w \mid (q_0, w, \perp) \overset{\ast}{\vdash} (q, \epsilon, \epsilon)\}$.
+$N(P) = \lbrace (w \mid (q_0, w, \perp) \overset{\ast}{\vdash} (q, \epsilon, \epsilon)\rbrace$.
 
 
 ## Deterministische PDAs

--- a/lecture/frontend/parsing/images/Def_PDA.tex
+++ b/lecture/frontend/parsing/images/Def_PDA.tex
@@ -14,7 +14,7 @@
 	$\Sigma$: & eine endliche Menge von Eingabesymbolen\\
 	$\Gamma$: & ein endliches Kelleralphabet\\
 	$\delta$: & die Übergangsfunktion\\
-	&$\delta$ : Q $\times$ $\Sigma$ $\cup$ $\{\epsilon\}$ $\times \Gamma \to 2^{Q \times
+	&$\delta$ : Q $\times$ $\Sigma$ $\cup$ $\lbrace \epsilon\rbrace$ $\times \Gamma \to 2^{Q \times
 		\Gamma^*{}}$ \\
 	$q_0$:& der Startzustand\\
 	$\perp \in \Gamma$: &  der anfängliche Kellerinhalt, symbolisiert den leeren\\

--- a/lecture/frontend/parsing/ll-parser.md
+++ b/lecture/frontend/parsing/ll-parser.md
@@ -161,7 +161,7 @@ und
 
 ##  Algorithmus: Entfernung von indirekter Linksrekursion {.fragile}
 
-**Eingabe:** Eine  Grammatik G = (N, T, P, S)  mit $N= \{X_1, X_2, \ldots X_n\}$ ohne $\epsilon$-Regeln oder Zyklen der Form $X_1 \rightarrow X_2, X_2 \rightarrow X_3, \ldots X_{m-1} \rightarrow X_m, X_m \rightarrow X_1$
+**Eingabe:** Eine  Grammatik G = (N, T, P, S)  mit $N= \lbrace X_1, X_2, \ldots X_n\rbrace$ ohne $\epsilon$-Regeln oder Zyklen der Form $X_1 \rightarrow X_2, X_2 \rightarrow X_3, \ldots X_{m-1} \rightarrow X_m, X_m \rightarrow X_1$
 
 **Ausgabe:** Eine äquivalente Grammatik $G'$ ohne Linksrekursion
 
@@ -181,7 +181,7 @@ Wir brauchen die "terminalen k-Anfänge" von Ableitungen von Nichtterminalen, um
 
 **Def.:** Wir definieren $First$ - Mengen einer Grammatik wie folgt:
 
-*   $a \in T^\ast, |a| \leq k: {First}_k (a) = \{a\}$
+*   $a \in T^\ast, |a| \leq k: {First}_k (a) = \lbrace a\rbrace$
 *   $a \in T^\ast, |a| > k: {First}_k (a) = \lbrace v \in T^\ast \mid a = vw, |v| = k\rbrace$
 *   $\alpha \in (N \cup T)^\ast \backslash T^\ast: {First}_k (\alpha) = \lbrace v \in T^\ast \mid  \alpha \overset{\ast}{\Rightarrow} w,\text{mit}\ w \in T^\ast, First_k(w) = \lbrace v \rbrace \rbrace$
 

--- a/lecture/frontend/semantics/attribgrammars.md
+++ b/lecture/frontend/semantics/attribgrammars.md
@@ -194,20 +194,20 @@ Eine *attributierte Grammatik* *AG = (G,A,R)* besteht aus folgenden Komponenten:
 
 *   A = $\bigcup\limits_{X \in (T \cup N)} A(X)$ mit $A(X) \cap A(Y) \neq \emptyset \Rightarrow X = Y$
 
-*   R = $\bigcup\limits_{p \in P} R(p)$ mit $R(p) = \{X_i.a = f(\ldots) \vert p : X_0 \rightarrow X_1 \ldots X_n \in P, X_i.a \in A(X_i), 0 \leq i \leq n\}$
+*   R = $\bigcup\limits_{p \in P} R(p)$ mit $R(p) = \lbrace X_i.a = f(\ldots) \vert p : X_0 \rightarrow X_1 \ldots X_n \in P, X_i.a \in A(X_i), 0 \leq i \leq n\rbrace$
 
 
 ## Abgeleitete und ererbte Attribute
 
 Die in einer Produktion definierten Attribute sind
 
-*AF(P)* = $\{X_i.a \ \vert\  p : X_0 \rightarrow X_1 \ldots X_n \in P,  0 \leq i \leq n, X_i.a = f(\ldots) \in R(p)\}$
+*AF(P)* = $\lbrace X_i.a \ \vert\  p : X_0 \rightarrow X_1 \ldots X_n \in P,  0 \leq i \leq n, X_i.a = f(\ldots) \in R(p)\rbrace$
 
 Wir betrachten Grammatiken mit zwei disjunkten Teilmengen, den abgeleiteten (synthesized) Attributen *AS(X)* und den ererbten (inherited) Attributen *AI(X)*:
 
-*AS(X)* = $\{X.a\ \vert \ \exists p : X \rightarrow X_1 \ldots X_n \in P, X.a \in AF(p)\}$
+*AS(X)* = $\lbrace X.a\ \vert \ \exists p : X \rightarrow X_1 \ldots X_n \in P, X.a \in AF(p)\rbrace$
 
-*AI(X)* = $\{X.a\ \vert \ \exists q : Y \rightarrow uXv \in P, X.a\in AF(q)\}$
+*AI(X)* = $\lbrace X.a\ \vert \ \exists q : Y \rightarrow uXv \in P, X.a\in AF(q)\rbrace$
 
 
 Abgeleitete Attribute geben Informationen von unten nach oben weiter, geerbte von oben nach unten.


### PR DESCRIPTION
We need to use `\lbrace` instead of `\{` and `\rbrace` instead of `\}` when converting to HTML using Hugo and **MathJax**.