### PR TITLE
lecture: fix links to annotated files (Regular)

### DIFF
--- a/lecture/01-lexing/regular1.md
+++ b/lecture/01-lexing/regular1.md
@@ -6,7 +6,7 @@ title: Reguläre Sprachen, Ausdrucksstärke (Teil 1)
 
 ::: attachments
 -   [Annotierte Folien: Reguläre Sprachen,
-    Ausdrucksstärke](https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/lexing_regular.ann.ba.pdf)
+    Ausdrucksstärke](https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/lexing_regular1.ann.ba.pdf)
 :::
 
 # Motivation

--- a/lecture/01-lexing/regular2.md
+++ b/lecture/01-lexing/regular2.md
@@ -6,7 +6,7 @@ title: Reguläre Sprachen, Ausdrucksstärke (Teil 2)
 
 ::: attachments
 -   [Annotierte Folien: Reguläre Sprachen,
-    Ausdrucksstärke](https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/lexing_regular.ann.ba.pdf)
+    Ausdrucksstärke](https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/lexing_regular2.ann.ba.pdf)
 :::
 
 # Wiederholung


### PR DESCRIPTION
das ist die einzige änderung in #384, die noch neu und ungemergt war. ich habe den damaligen commit https://github.com/Compiler-CampusMinden/CB-Vorlesung-Bachelor/pull/384/commits/bf43eda3a9bcb2cf2b0d08791c59901882bab5a9 per cherry-pick übernommen. 

dieser pr ersetzt damit #384.

closes #384